### PR TITLE
Change Retro68 package from 'standalone' to 'monolithic'

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,15 +7,15 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1711822907,
-        "narHash": "sha256-xohWyQWGWR89057JQAnOAXmkrOvV+tk3wNwLKru+IR8=",
-        "owner": "agoode",
+        "lastModified": 1712187909,
+        "narHash": "sha256-G7G/zuP4+1hfyH7fT6hjlFgC48jTm6h5iUQw+F2v9Uc=",
+        "owner": "jcreedcmu",
         "repo": "Retro68",
-        "rev": "e3af78010b9cc608d2bbe41124d8930c157bcd5d",
+        "rev": "c90cdebf95e4c697de3b335e6310d82288c5f1e3",
         "type": "github"
       },
       "original": {
-        "owner": "agoode",
+        "owner": "jcreedcmu",
         "ref": "mlton",
         "repo": "Retro68",
         "type": "github"

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs";
-    Retro68.url = "github:agoode/Retro68/mlton";
+    Retro68.url = "github:jcreedcmu/Retro68/mlton";
     flake-utils.url = "github:numtide/flake-utils";
     mlton-src = { url = "github:agoode/mlton/mac"; flake = false; };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,8 @@
     with builtins;
     flake-utils.lib.eachDefaultSystem (system:
       let pkgs = nixpkgs.legacyPackages.${system};
-          retro68 = Retro68.packages.${system}.standalone;
+          pkgs-retro68 = import nixpkgs { inherit system; overlays = [ Retro68.overlays.default ]; };
+          retro68 = pkgs-retro68.retro68.monolithic;
       in
         {
           packages = rec {


### PR DESCRIPTION
This doesn't work yet. The tail of the errors arising from
```
nix develop .#mlton-m68k-runtime
```
are
```
       > checking for cos in -lm... yes
       > configure: updating cache ./config.cache
       > checking that generated files are newer than configure... done
       > configure: creating ./config.status
       > config.status: creating Makefile
       > config.status: creating po/Makefile.in
       > config.status: creating config.h
       > config.status: executing depfiles commands
       > config.status: executing libtool commands
       > config.status: executing default-1 commands
       > config.status: creating po/POTFILES
       > config.status: creating po/Makefile
       > make[1]: Leaving directory '/build/binutils-build'
       > make: *** [Makefile:1003: all] Error 2
```
and I don't understand yet.