### PR TITLE
Move twelf execution slices to idle portion of main event loop

### DIFF
--- a/docker/twelf-app/global-state.c
+++ b/docker/twelf-app/global-state.c
@@ -8,3 +8,5 @@ SysEnvRec gMac;
 Boolean gHasWaitNextEvent;
 Boolean gInBackground;
 short gNumDocuments;
+
+TwelfStatus gTwelfStatus = TWELF_STATUS_NOT_RUNNING;

--- a/docker/twelf-app/global-state.h
+++ b/docker/twelf-app/global-state.h
@@ -34,3 +34,12 @@ extern Boolean gInBackground; /* maintained by Initialize and DoEvent */
  */
 extern short
     gNumDocuments; /* maintained by Initialize, DoNew, and DoCloseWindow */
+
+/* Keep track of whether twelf evaluation is currently running in the
+ * background. */
+typedef enum {
+  TWELF_STATUS_NOT_RUNNING,
+  TWELF_STATUS_RUNNING,
+} TwelfStatus;
+
+extern TwelfStatus gTwelfStatus;

--- a/docker/twelf-app/menus.c
+++ b/docker/twelf-app/menus.c
@@ -336,29 +336,9 @@ void DoMenuCommand(long menuResult) {
           }
           logger("swizzled %d bytes from CR to NL...", len);
 
-          int resp;
-          do {
-            logger("Executing a little twelf...");
-            resp = execute_for_milliseconds(20);
-            // TODO: Go all the way back up to the main loop each time.
-          } while (resp == -1);
-          logger("Twelf response: %d", resp);
-
-          // XXX raise an alert if abort?
-          setOutputDest(NULL);
-          char *abortStr = "%% ABORT %%";
-          char *okStr = "%% OK %%";
-          TEInsert(resp ? abortStr : okStr,
-                   resp ? strlen(abortStr) : strlen(okStr), outDoc->docTE);
-          // Scroll to insertion point
-          TESelView(outDoc->docTE);
-          // Update scrollbars as necessary
-          AdjustScrollValues(outDoc, false);
-          // I couldn't seem to get by with anything less than this, which
-          // includes a whole EraseWindow. I tried just TEUpdate, I tried just
-          // InvalRect, but when the output string grew shorter, it left
-          // graphical cruft behind.
-          DrawWindow(outWin);
+          gTwelfStatus = TWELF_STATUS_RUNNING;
+          // Actual twelf evaluation happens inside DoIdle when
+          // TWELF_STATUS_RUNNING is true.
         } break;
         case iEvalUnsafe: {
         } break;

--- a/docker/twelf-app/menus.c
+++ b/docker/twelf-app/menus.c
@@ -143,15 +143,21 @@ void AdjustSignatureMenu() {
   WindowPtr window = FrontWindow();
   MenuHandle menu = GetMenuHandle(mSignature);
 
-  Boolean enabled = false;
+  Boolean evaluationEnabled = false;
+  Boolean cancellationEnabled = gTwelfStatus == TWELF_STATUS_RUNNING;
+
+  DisableItem(menu, iEval);
+  DisableItem(menu, iEvalUnsafe);
+  DisableItem(menu, iCancelEval);
 
   if (IsAppWindow(window)) {
     TwelfWinPtr twin = (TwelfWinPtr)window;
     switch (twin->winType) {
       case TwelfWinDocument: {
         DocumentPtr doc = getDoc(window);
-        if (!isReadOnly(doc->docType)) {
-          enabled = true;
+        if (!isReadOnly(doc->docType) &&
+            gTwelfStatus == TWELF_STATUS_NOT_RUNNING) {
+          evaluationEnabled = true;
         }
       } break;
       case TwelfWinAbout: {
@@ -159,12 +165,12 @@ void AdjustSignatureMenu() {
     }
   }
 
-  if (enabled) {
+  if (evaluationEnabled) {
     EnableItem(menu, iEval);
-    // EnableItem(menu, iEvalUnsafe);
-  } else {
-    DisableItem(menu, iEval);
-    DisableItem(menu, iEvalUnsafe);
+  }
+
+  if (cancellationEnabled) {
+    EnableItem(menu, iCancelEval);
   }
 
   EnableItem(menu, iShowLog);
@@ -341,6 +347,15 @@ void DoMenuCommand(long menuResult) {
           // TWELF_STATUS_RUNNING is true.
         } break;
         case iEvalUnsafe: {
+        } break;
+        case iCancelEval: {
+          /* Theoretically we might have had to do some explicit
+           * cleanup here, but for now we believe it's safe to just
+           * stop running the twelf thread, and by the time we start
+           * another twelf evaluation, it will clean up the previous
+           * one.
+           */
+          gTwelfStatus = TWELF_STATUS_NOT_RUNNING;
         } break;
         case iShowLog: {
           if (gLogWindow != NULL) {

--- a/docker/twelf-app/resource-consts.h
+++ b/docker/twelf-app/resource-consts.h
@@ -29,7 +29,8 @@
 #define mSignature 131 /* Signature menu */
 #define iEval 1
 #define iEvalUnsafe 2
-#define iShowLog 4
+#define iCancelEval 3
+#define iShowLog 5
 
 #define rMenuBar 128      /* application's menu bar */
 #define rCloseConfirm 128 /* close-confirm dialog box */

--- a/docker/twelf-app/twelf.r
+++ b/docker/twelf-app/twelf.r
@@ -78,6 +78,8 @@ resource 'MENU' (mSignature, preload) {
 			noicon, "E", nomark, plain;
 		"Evaluate Unsafe",
 			noicon, "U", nomark, plain;
+		"Cancel Evaluation",
+			noicon, ".", nomark, plain;
 		"-",
 		   noicon, nokey, nomark, plain;
 		"Show Debug Log",


### PR DESCRIPTION
Resolves #34 and #36. When I run a big development like `classical-s5.elf`, I can still manipulate the user interface while it runs for a few seconds. This seems to be evidence that it's working. Cancellation, implemented as a menu command with conventional shortcut ⌘-. seems to work ok. I can ⌘-E and ⌘-. in quick succession on `classical-s5.elf`, and it only gets partway through checking, as evidenced by the output in the output window.